### PR TITLE
Update playsample.js and use new MediaStreamTrack.stop() instead of MediaStream.stop()

### DIFF
--- a/src/Microphone.js
+++ b/src/Microphone.js
@@ -142,7 +142,7 @@ Microphone.prototype.stop = function() {
   if (!this.recording)
     return;
   this.recording = false;
-  this.stream.stop();
+  this.stream.getTracks()[0].stop();
   this.requestedAccess = false;
   this.mic.disconnect(0);
   this.mic = null;

--- a/src/views/playsample.js
+++ b/src/views/playsample.js
@@ -40,21 +40,22 @@ var playSample = (function() {
 
   var running = false;
   localStorage.setItem('currentlyDisplaying', 'false');
+  localStorage.setItem('samplePlaying', 'false');
 
-  return function(token, imageTag, iconName, url) {
+  return function(token, imageTag, sampleNumber, iconName, url) {
 
     $.publish('clearscreen');
 
     var currentlyDisplaying = localStorage.getItem('currentlyDisplaying');
-
+    var samplePlaying = localStorage.getItem('samplePlaying');  
+      
     console.log('CURRENTLY DISPLAYING', currentlyDisplaying);
 
-    // This error handling needs to be expanded to accomodate
-    // the two different play samples files
-    if (currentlyDisplaying==='sample') {
+    if (samplePlaying==sampleNumber) {
       console.log('HARD SOCKET STOP');
       $.publish('socketstop');
       localStorage.setItem('currentlyDisplaying', 'false');
+      localStorage.setItem('samplePlaying', 'false');
       effects.stopToggleImage(timer, imageTag, iconName);
       effects.restoreImage(imageTag, iconName);
       running = false;
@@ -64,12 +65,13 @@ var playSample = (function() {
     if (currentlyDisplaying=='record') {
       showError('Currently audio is being recorded, please stop recording before playing a sample');
       return;
-    } else if (currentlyDisplaying=='fileupload') {
+    } else if (currentlyDisplaying=='fileupload'||samplePlaying!='false') {
       showError('Currently another file is playing, please stop the file or wait until it finishes');
       return;
     }
 
     localStorage.setItem('currentlyDisplaying', 'sample');
+    localStorage.setItem('samplePlaying', sampleNumber);
     running = true;
 
     $('#resultsText').val('');   // clear hypotheses from previous runs
@@ -133,6 +135,7 @@ var playSample = (function() {
             effects.stopToggleImage(timer, imageTag, iconName);
             effects.restoreImage(imageTag, iconName);
             localStorage.getItem('currentlyDisplaying', 'false');
+            localStorage.setItem('samplePlaying', 'false');
           }
         );
       };
@@ -151,7 +154,7 @@ exports.initPlaySample = function(ctx) {
     var iconName = 'play';
     var imageTag = el.find('img');
     el.click( function() {
-      playSample(ctx.token, imageTag, iconName, fileName, function(result) {
+      playSample(ctx.token, imageTag, 'sample-1', iconName, fileName, function(result) {
         console.log('Play sample result', result);
       });
     });
@@ -164,7 +167,7 @@ exports.initPlaySample = function(ctx) {
     var iconName = 'play';
     var imageTag = el.find('img');
     el.click( function() {
-      playSample(ctx.token, imageTag, iconName, fileName, function(result) {
+      playSample(ctx.token, imageTag, 'sample-2', iconName, fileName, function(result) {
         console.log('Play sample result', result);
       });
     });


### PR DESCRIPTION
this change updates playsample.js to allow the two samples to work independently. Now, they have independent functionalities and one won't stop the other on clicking.