### PR TITLE
Retract support for recording audio in firefox

### DIFF
--- a/src/Microphone.js
+++ b/src/Microphone.js
@@ -23,6 +23,7 @@ var utils = require('./utils');
  */
 function Microphone(_options) {
   var options = _options || {};
+  var showError = require('./views/showerror').showError;
 
   // we record in mono because the speech recognition service
   // does not support stereo.
@@ -38,7 +39,7 @@ function Microphone(_options) {
   // Chrome or Firefox or IE User media
   if (!navigator.getUserMedia) {
     navigator.getUserMedia = navigator.webkitGetUserMedia ||
-    navigator.mozGetUserMedia || navigator.msGetUserMedia;
+    /*navigator.mozGetUserMedia ||*/ navigator.msGetUserMedia;
   }
 
 }
@@ -55,6 +56,9 @@ Microphone.prototype.onPermissionRejected = function() {
 
 Microphone.prototype.onError = function(error) {
   console.log('Microphone.onError():', error);
+  if(error==="Browser doesn't support microphone input") {
+    showError('The record audio functionality is currently supported  on Google Chrome only.');
+  }
 };
 
 /**

--- a/src/Microphone.js
+++ b/src/Microphone.js
@@ -18,7 +18,6 @@
 
 var utils = require('./utils');
 var showError = require('./views/showerror').showError;
-
 /**
  * Captures microphone input from the browser.
  * Works at least on latest versions of Firefox and Chrome

--- a/src/Microphone.js
+++ b/src/Microphone.js
@@ -17,13 +17,14 @@
 'use strict';
 
 var utils = require('./utils');
+var showError = require('./views/showerror').showError;
+
 /**
  * Captures microphone input from the browser.
  * Works at least on latest versions of Firefox and Chrome
  */
 function Microphone(_options) {
   var options = _options || {};
-  var showError = require('./views/showerror').showError;
 
   // we record in mono because the speech recognition service
   // does not support stereo.


### PR DESCRIPTION
This change removes support for audio recording in firefox, until further notice.