### PR TITLE
Update link

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ This data is collected from the `package.json` file in the sample application an
 
 [deploy_track_url]: https://github.com/cloudant-labs/deployment-tracker
 [cloud_foundry]: https://github.com/cloudfoundry/cli
-[getting_started]: https://www.ibm.com/watson/developercloud/doc/getting_started/
+[getting_started]: https://www.ibm.com/watson/developercloud/doc/common/index.html
 [service_url]: http://www.ibm.com/watson/developercloud/speech-to-text.html
 [docs]: http://www.ibm.com/watson/developercloud/speech-to-text/
 [sign_up]: https://console.ng.bluemix.net/registration/


### PR DESCRIPTION
getting_started content moved with conversion to Markdown

no text was harmed in the making of this pull request. Only real change should be the link