### PR TITLE
Fix dropdown models binding

### DIFF
--- a/views/model-dropdown.jsx
+++ b/views/model-dropdown.jsx
@@ -13,6 +13,7 @@ export class ModelDropdown extends Component {
     super();
     // initialize with a (possibly outdated) cached JSON models file,
     // then update it once we have a token
+    this.handleChange = this.handleChange.bind(this);
     this.state = { models: cachedModels }
   }
 


### PR DESCRIPTION
The actual demo (available [online](https://speech-to-text-demo.ng.bluemix.net)) isn't working properly.

The models dropdown didn't work, so I fixed it.
`this.props` was `undefined`

Enjoy,
Julien