### PR TITLE
feat(Layout): add link to Terms of Use

### DIFF
--- a/views/layout.jsx
+++ b/views/layout.jsx
@@ -5,6 +5,7 @@ import { Header, Jumbotron } from 'watson-react-components';
 // eslint-disable-mnext-lin =
 const DESCRIPTION = 'The IBM Watson Speech to Text service uses speech recognition capabilities to convert Arabic, English, Spanish, French, Brazilian Portuguese, Japanese, Korean, German, and Mandarin speech into text.';
 const GDPR_INFO = 'This system is for demonstration purposes only and is not intended to process Personal Data. No Personal Data is to be entered into this system as it may not have the necessary controls in place to meet the requirements of the General Data Protection Regulation (EU) 2016/679';
+const TERMS_OF_USE_URL = 'https://watson-developer-cloud.github.io/terms?name=Speech-to-Text%20Demo';
 
 export default function Layout({ children }) {
   return (
@@ -40,6 +41,12 @@ export default function Layout({ children }) {
 
         <div className="_container _container_large gdpr-info">
           {GDPR_INFO}
+        </div>
+        <div className="_container _container_large gdpr-info">
+          By using this application, you agree to the &nbsp;
+          <a target="_blank" rel="noreferrer noopener" href={TERMS_OF_USE_URL}>
+                Terms of Use
+          </a>
         </div>
         <div id="root">
           {children}


### PR DESCRIPTION
This adds a link to the Terms of Use in the layout, underneath the GDPR statement

![image](https://user-images.githubusercontent.com/4694018/57794366-743fd300-7711-11e9-8a2c-a45f8a08d4af.png)
