### PR TITLE
fix(Express): properly format basic auth creds

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,10 +60,7 @@ app.get('/api/v1/credentials', (req, res, next) => {
           serviceUrl,
         };
       } else {
-        credentials = {
-          token,
-          serviceUrl,
-        };
+        credentials = token;
       }
       res.json(credentials);
     }

--- a/app.js
+++ b/app.js
@@ -60,7 +60,10 @@ app.get('/api/v1/credentials', (req, res, next) => {
           serviceUrl,
         };
       } else {
-        credentials = token;
+        credentials = {
+          token: token.token,
+          serviceUrl,
+        };
       }
       res.json(credentials);
     }

--- a/test/unit/offline.test.js
+++ b/test/unit/offline.test.js
@@ -27,7 +27,7 @@ describe('offline tests', () => {
       nock('https://stream.watsonplatform.net:443', { encodedQueryParams: true })
         .get('/authorization/api/v1/token')
         .query({ url: 'https://stream.watsonplatform.net/speech-to-text/api' })
-        .reply(200, 'faketoken', {
+        .reply(200, fakeToken, {
           connection: 'close',
           'transfer-encoding': 'chunked',
           'content-type': 'text/xml',


### PR DESCRIPTION
previously, some object shorthand was being done, which caused the credential object to be
improperly nested under a "token" key. this caused the frontend code to pass an object instead of
the actual api key, which broke all websocket connections.

@germanattanasio as we discussed. if you can review quickly i'd appreciate it as this bug is causing issues in the live demo. thanks 👍 