### PR TITLE
Add data for newly captured voice models

### DIFF
--- a/src/data/samples.json
+++ b/src/data/samples.json
@@ -115,6 +115,176 @@
       "speaker_labels": false
     }
   ],
+  "es-AR_BroadbandModel": [
+    {
+      "filename": "es-ES_Broadband_sample1.wav",
+      "keywords": "Roberto, Pedro",
+      "speaker_labels": true
+    },
+    {
+      "filename": "es-ES_Broadband_sample2.wav",
+      "keywords": "México, Grecia",
+      "speaker_labels": true
+    }
+  ],
+  "es-AR_NarrowbandModel": [
+    {
+      "filename": "es-ES_Narrowband_sample1.wav",
+      "keywords": "México, Grecia, diciembre",
+      "speaker_labels": true
+    },
+    {
+      "filename": "es-ES_Narrowband_sample2.wav",
+      "keywords": "Roberto, Madrid, fin de semana",
+      "speaker_labels": true
+    },
+    {
+      "filename": "Es_ES_spk24_8khz.wav",
+      "keywords": "quiero preguntarle, existen productos",
+      "speaker_labels": false
+    },
+    {
+      "filename": "Es_ES_spk19_8khz.wav",
+      "keywords": "preparando, regalos para la familia, sobrinos",
+      "speaker_labels": false
+    }
+  ],
+  "es-CL_BroadbandModel": [
+    {
+      "filename": "es-ES_Broadband_sample1.wav",
+      "keywords": "Roberto, Pedro",
+      "speaker_labels": true
+    },
+    {
+      "filename": "es-ES_Broadband_sample2.wav",
+      "keywords": "México, Grecia",
+      "speaker_labels": true
+    }
+  ],
+  "es-CL_NarrowbandModel": [
+    {
+      "filename": "es-ES_Narrowband_sample1.wav",
+      "keywords": "México, Grecia, diciembre",
+      "speaker_labels": true
+    },
+    {
+      "filename": "es-ES_Narrowband_sample2.wav",
+      "keywords": "Roberto, Madrid, fin de semana",
+      "speaker_labels": true
+    },
+    {
+      "filename": "Es_ES_spk24_8khz.wav",
+      "keywords": "quiero preguntarle, existen productos",
+      "speaker_labels": false
+    },
+    {
+      "filename": "Es_ES_spk19_8khz.wav",
+      "keywords": "preparando, regalos para la familia, sobrinos",
+      "speaker_labels": false
+    }
+  ],
+  "es-CO_BroadbandModel": [
+    {
+      "filename": "es-ES_Broadband_sample1.wav",
+      "keywords": "Roberto, Pedro",
+      "speaker_labels": true
+    },
+    {
+      "filename": "es-ES_Broadband_sample2.wav",
+      "keywords": "México, Grecia",
+      "speaker_labels": true
+    }
+  ],
+  "es-CO_NarrowbandModel": [
+    {
+      "filename": "es-ES_Narrowband_sample1.wav",
+      "keywords": "México, Grecia, diciembre",
+      "speaker_labels": true
+    },
+    {
+      "filename": "es-ES_Narrowband_sample2.wav",
+      "keywords": "Roberto, Madrid, fin de semana",
+      "speaker_labels": true
+    },
+    {
+      "filename": "Es_ES_spk24_8khz.wav",
+      "keywords": "quiero preguntarle, existen productos",
+      "speaker_labels": false
+    },
+    {
+      "filename": "Es_ES_spk19_8khz.wav",
+      "keywords": "preparando, regalos para la familia, sobrinos",
+      "speaker_labels": false
+    }
+  ],
+  "es-MX_BroadbandModel": [
+    {
+      "filename": "es-ES_Broadband_sample1.wav",
+      "keywords": "Roberto, Pedro",
+      "speaker_labels": true
+    },
+    {
+      "filename": "es-ES_Broadband_sample2.wav",
+      "keywords": "México, Grecia",
+      "speaker_labels": true
+    }
+  ],
+  "es-MX_NarrowbandModel": [
+    {
+      "filename": "es-ES_Narrowband_sample1.wav",
+      "keywords": "México, Grecia, diciembre",
+      "speaker_labels": true
+    },
+    {
+      "filename": "es-ES_Narrowband_sample2.wav",
+      "keywords": "Roberto, Madrid, fin de semana",
+      "speaker_labels": true
+    },
+    {
+      "filename": "Es_ES_spk24_8khz.wav",
+      "keywords": "quiero preguntarle, existen productos",
+      "speaker_labels": false
+    },
+    {
+      "filename": "Es_ES_spk19_8khz.wav",
+      "keywords": "preparando, regalos para la familia, sobrinos",
+      "speaker_labels": false
+    }
+  ],
+  "es-PE_BroadbandModel": [
+    {
+      "filename": "es-ES_Broadband_sample1.wav",
+      "keywords": "Roberto, Pedro",
+      "speaker_labels": true
+    },
+    {
+      "filename": "es-ES_Broadband_sample2.wav",
+      "keywords": "México, Grecia",
+      "speaker_labels": true
+    }
+  ],
+  "es-PE_NarrowbandModel": [
+    {
+      "filename": "es-ES_Narrowband_sample1.wav",
+      "keywords": "México, Grecia, diciembre",
+      "speaker_labels": true
+    },
+    {
+      "filename": "es-ES_Narrowband_sample2.wav",
+      "keywords": "Roberto, Madrid, fin de semana",
+      "speaker_labels": true
+    },
+    {
+      "filename": "Es_ES_spk24_8khz.wav",
+      "keywords": "quiero preguntarle, existen productos",
+      "speaker_labels": false
+    },
+    {
+      "filename": "Es_ES_spk19_8khz.wav",
+      "keywords": "preparando, regalos para la familia, sobrinos",
+      "speaker_labels": false
+    }
+  ],
   "ja-JP_BroadbandModel": [
     {
       "filename": "ja-JP_Broadband_sample1.wav",


### PR DESCRIPTION
Currently, there's an issue where there are some new models which do not have associated sample audio or keywords. This is resulting in an error when users try to play the sample audio:

![image](https://user-images.githubusercontent.com/8710772/68699893-f179c280-0551-11ea-8dc1-d223086c01f6.png)

The models in question are:
- `es-AR_BroadbandModel`
- `es-AR_NarrowbandModel`
- `es-CL_BroadbandModel`
- `es-CL_NarrowbandModel`
- `es-CO_BroadbandModel`
- `es-CO_NarrowbandModel`
- `es-MX_BroadbandModel`
- `es-MX_NarrowbandModel`
- `es-PE_BroadbandModel`
- `es-PE_NarrowbandModel`

This PR just points those models to the same sample files and keywords used by the `es-ES_BroadbandModel` and `es-ES_NarrowbandModel` models for now, since the service team does not have real audio files ready for us to use.

Demo:

![demo-fix](https://user-images.githubusercontent.com/8710772/68700632-39e5b000-0553-11ea-84f0-3fb8084e6c4b.gif)