### PR TITLE
Fix the IAM access issues

### DIFF
--- a/views/demo.jsx
+++ b/views/demo.jsx
@@ -113,7 +113,7 @@ export class Demo extends Component {
       objectMode: true,
       interimResults: true,
       // note: in normal usage, you'd probably set this a bit higher
-      wordAlternatives_threshold: 0.01,
+      wordAlternativesThreshold: 0.01,
       keywords,
       keywordsThreshold: keywords.length
         ? 0.01

--- a/views/demo.jsx
+++ b/views/demo.jsx
@@ -105,22 +105,22 @@ export class Demo extends Component {
     const keywords = this.getKeywordsArrUnique();
     return Object.assign({
       // formats phone numbers, currency, etc. (server-side)
-      access_token: this.state.accessToken,
+      accessToken: this.state.accessToken,
       token: this.state.token,
-      smart_formatting: true,
+      smartFormatting: true,
       format: true, // adds capitals, periods, and a few other things (client-side)
       model: this.state.model,
       objectMode: true,
-      interim_results: true,
+      interimResults: true,
       // note: in normal usage, you'd probably set this a bit higher
-      word_alternatives_threshold: 0.01,
+      wordAlternatives_threshold: 0.01,
       keywords,
-      keywords_threshold: keywords.length
+      keywordsThreshold: keywords.length
         ? 0.01
         : undefined, // note: in normal usage, you'd probably set this a bit higher
       timestamps: true, // set timestamps for each word - automatically turned on by speaker_labels
       // includes the speaker_labels in separate objects unless resultsBySpeaker is enabled
-      speaker_labels: this.state.speakerLabels,
+      speakerLabels: this.state.speakerLabels,
       // combines speaker_labels and results together into single objects,
       // making for easier transcript outputting
       resultsBySpeaker: this.state.speakerLabels,
@@ -499,7 +499,7 @@ export class Demo extends Component {
             <p>Voice Model:
               <ModelDropdown
                 model={model}
-                token={token || accessToken}
+                accessToken={token || accessToken}
                 onChange={this.handleModelChange}
               />
             </p>

--- a/views/model-dropdown.jsx
+++ b/views/model-dropdown.jsx
@@ -30,8 +30,8 @@ export class ModelDropdown extends Component {
     }
   }
 
-  fetchModels(token) {
-    SpeechToText.getModels({ token }).then(models => this.setState({ models }))
+  fetchModels(accessToken) {
+    SpeechToText.getModels({ accessToken }).then(models => this.setState({ models }))
       .catch(err => console.log('error loading models', err));
   }
 
@@ -70,7 +70,7 @@ export class ModelDropdown extends Component {
 
 ModelDropdown.propTypes = {
   model: PropTypes.string.isRequired,
-  token: PropTypes.string,
+  accessToken: PropTypes.string,
   onChange: PropTypes.func,
 };
 


### PR DESCRIPTION
When I run the Watson speech2text demo in my local and cloud CF, and encountered several issues related to the IAM authentication. Part of the issues are recorded in these two issues:

https://github.com/watson-developer-cloud/speech-to-text-nodejs/issues/265
https://github.com/watson-developer-cloud/speech-to-text-nodejs/issues/264

And finally I resolved the issues by this code change.

Hope you can review and merge the change.

BTW, I didn't test regression on the watson-token access, but I think this already deprecated. 

Thanks,
Bali